### PR TITLE
Set GenerationType.IDENTITY for GeneratedValue fields by default

### DIFF
--- a/sample/src/main/resources/entityGenConfig.yml
+++ b/sample/src/main/resources/entityGenConfig.yml
@@ -25,6 +25,8 @@ jpa1SupportRequired: true
 #   - string value: full package name separate from the "packageName"
 packageNameForJpa1: "com.example.entity.jpa1"
 
+generatedValueStrategy: null
+
 # ---------------------------------------------------------
 # *** Rules for exclusion ***
 

--- a/src/main/java/com/smartnews/jpa_entity_generator/CodeGenerator.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/CodeGenerator.java
@@ -10,6 +10,7 @@ import com.smartnews.jpa_entity_generator.util.TypeConverter;
 import freemarker.template.TemplateException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.SerializationUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -123,6 +124,9 @@ public class CodeGenerator {
                                 .filter(r -> r.matches(className, fieldName)).findFirst();
                 if (fieldDefaultValueRule.isPresent()) {
                     f.setDefaultValue(fieldDefaultValueRule.get().getDefaultValue());
+                }
+                if (StringUtils.isNotEmpty(config.getGeneratedValueStrategy())) {
+                    f.setGeneratedValueStrategy(config.getGeneratedValueStrategy());
                 }
 
                 f.setAutoIncrement(c.isAutoIncrement());

--- a/src/main/java/com/smartnews/jpa_entity_generator/CodeRenderer.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/CodeRenderer.java
@@ -77,6 +77,7 @@ public class CodeRenderer {
             private String defaultValue;
             private boolean primaryKey;
             private boolean autoIncrement;
+            private String generatedValueStrategy;
             private List<Annotation> annotations = new ArrayList<>();
         }
     }

--- a/src/main/java/com/smartnews/jpa_entity_generator/config/CodeGeneratorConfig.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/config/CodeGeneratorConfig.java
@@ -61,6 +61,11 @@ public class CodeGeneratorConfig implements Serializable {
     private List<String> tableNames = new ArrayList<>();
     private List<TableExclusionRule> tableExclusionRules = new ArrayList<>();
 
+    // @GeneratedValue(strategy = GenerationType.IDENTITY)
+    // Possible values: TABLE, SEQUENCE, IDENTITY, AUTO
+    // If you don't need to specify the `strategy`, set null value.
+    private String generatedValueStrategy = "IDENTITY";
+
     private String outputDirectory = "src/main/java";
     private String packageName = "com.smartnews.db";
     private String packageNameForJpa1 = "com.smartnews.db.jpa1";

--- a/src/main/resources/entityGen/entity.ftl
+++ b/src/main/resources/entityGen/entity.ftl
@@ -37,7 +37,11 @@ ${field.comment}
   @Id
 </#if>
 <#if field.autoIncrement>
+  <#if field.generatedValueStrategy?has_content>
+  @GeneratedValue(strategy = GenerationType.${field.generatedValueStrategy})
+  <#else>
   @GeneratedValue
+  </#if>
 </#if>
 <#list field.annotations as annotation>
   ${annotation.toString()}

--- a/src/test/java/com/example/entity/Blog.java
+++ b/src/test/java/com/example/entity/Blog.java
@@ -18,11 +18,11 @@ import lombok.ToString;
 public class Blog implements Serializable {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "\"id\"")
   private Integer id;
   @Column(name = "\"name\"")
-  private String name = "Anonymous";
+  private String name;
   @Column(name = "\"active\"")
   private boolean active;
   @Column(name = "\"created_at\"")

--- a/src/test/java/com/example/entity/BlogArticle.java
+++ b/src/test/java/com/example/entity/BlogArticle.java
@@ -18,7 +18,7 @@ public class BlogArticle implements Serializable {
   public Integer getId() { return this.id; }
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "\"id\"")
   private Integer id;
   /**
@@ -27,7 +27,7 @@ public class BlogArticle implements Serializable {
   @Column(name = "\"blog_id\"")
   private Integer blogId;
   @Column(name = "\"name\"")
-  private String name = "Anonymous";
+  private String name;
   @Deprecated
   @Column(name = "\"tags\"")
   private Clob tags;

--- a/src/test/java/com/example/entity/BlogArticleTag.java
+++ b/src/test/java/com/example/entity/BlogArticleTag.java
@@ -18,7 +18,7 @@ public class BlogArticleTag implements Serializable {
   public Integer getId() { return this.id; }
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "\"id\"")
   private Integer id;
   /**

--- a/src/test/java/com/example/entity/Tag.java
+++ b/src/test/java/com/example/entity/Tag.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 public class Tag implements Serializable {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "\"id\"")
   private Integer id;
   @Column(name = "\"tag\"")

--- a/src/test/java/com/example/entity/jpa1/Blog.java
+++ b/src/test/java/com/example/entity/jpa1/Blog.java
@@ -18,11 +18,11 @@ import lombok.ToString;
 public class Blog implements Serializable {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "`id`")
   private Integer id;
   @Column(name = "`name`")
-  private String name = "Anonymous";
+  private String name;
   @Column(name = "`active`")
   private boolean active;
   @Column(name = "`created_at`")

--- a/src/test/java/com/example/entity/jpa1/BlogArticle.java
+++ b/src/test/java/com/example/entity/jpa1/BlogArticle.java
@@ -18,7 +18,7 @@ public class BlogArticle implements Serializable {
   public Integer getId() { return this.id; }
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "`id`")
   private Integer id;
   /**
@@ -27,7 +27,7 @@ public class BlogArticle implements Serializable {
   @Column(name = "`blog_id`")
   private Integer blogId;
   @Column(name = "`name`")
-  private String name = "Anonymous";
+  private String name;
   @Deprecated
   @Column(name = "`tags`")
   private Clob tags;

--- a/src/test/java/com/example/entity/jpa1/BlogArticleTag.java
+++ b/src/test/java/com/example/entity/jpa1/BlogArticleTag.java
@@ -18,7 +18,7 @@ public class BlogArticleTag implements Serializable {
   public Integer getId() { return this.id; }
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "`id`")
   private Integer id;
   /**

--- a/src/test/java/com/example/entity/jpa1/Tag.java
+++ b/src/test/java/com/example/entity/jpa1/Tag.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 public class Tag implements Serializable {
 
   @Id
-  @GeneratedValue
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "`id`")
   private Integer id;
   @Column(name = "`tag`")

--- a/src/test/resources/entityGenConfig.yml
+++ b/src/test/resources/entityGenConfig.yml
@@ -161,7 +161,7 @@ fieldAdditionalCommentRules:
 #     - defaultValue (string): the default value part in source code (specify '"something"' if you have a string value)
 fieldDefaultValueRules:
   # If you don't specify classNames in a rule, all the generated classes will be affected.
-  - {                        fieldNames: ["name"],   defaultValue: '"Anonymous"'}
+#  - {                        fieldNames: ["name"],   defaultValue: '"Anonymous"'}
   - {classNames: ["ABTest"], fieldNames: ["active"], defaultValue: "0"}
 
 # ---------------------------------------------------------

--- a/test.sh
+++ b/test.sh
@@ -4,5 +4,5 @@
 cd sample && \
 ./gradlew entityGen && \
 cp -pr db testdb && \
-#git diff --exit-code && \
+git diff --exit-code && \
 ./gradlew test


### PR DESCRIPTION
Not explicitly specifying `strategy` attribute of `GeneratedValue` doesn't always work with MySQL. This pull request changes the default behavior to append the strategy. It also provides the way to disable it for backward-compatibilities.