### PR TITLE
Refactoring build file.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,17 @@ dependencies {
     compile 'org.freemarker:freemarker:2.3.28'
     compile 'org.yaml:snakeyaml:1.21'
     compile 'org.slf4j:slf4j-api:1.7.25'
-    providedCompile 'org.projectlombok:lombok:1.16.20'
+
+    compileOnly 'org.projectlombok:lombok:1.16.20'
+
     providedCompile gradleApi()
     providedCompile 'org.apache.maven:maven-plugin-api:3.5.3'
+
     testCompile 'junit:junit:4.12'
     testCompile 'com.h2database:h2:1.4.197'
     testCompile 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final'
+
+    testCompileOnly 'org.projectlombok:lombok:1.16.20'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,11 @@ allprojects {
             options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
         }
     }
+
+    // http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+    }
 }
 
 
@@ -121,11 +126,3 @@ uploadArchives {
     }
 }
 } catch (MissingPropertyException e) { e.printStackTrace() }
-
-// http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
-allprojects {
-    tasks.withType(Javadoc) {
-        options.addStringOption('Xdoclint:none', '-quiet')
-    }
-}
-

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,10 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
+plugins {
+    id 'java'
+    id 'idea'
+    id 'maven'
+    id 'signing'
+    id 'com.dorongold.task-tree' version '1.3'
 }
-
-apply plugin: 'java'
-apply plugin: 'idea'
 
 compileJava {
     sourceCompatibility = '1.8'
@@ -57,8 +56,6 @@ allprojects {
     }
 }
 
-apply plugin: 'maven'
-apply plugin: 'signing'
 
 task javadocJar(type: Jar) {
     classifier = 'javadoc'
@@ -131,17 +128,4 @@ allprojects {
         options.addStringOption('Xdoclint:none', '-quiet')
     }
 }
-
-// ./gradlew taskTree {task name}
-buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath "gradle.plugin.com.dorongold.plugins:task-tree:1.3"
-  }
-}
-apply plugin: "com.dorongold.task-tree"
 

--- a/sample-wordpress/build.gradle
+++ b/sample-wordpress/build.gradle
@@ -9,7 +9,7 @@ buildscript {
   }
   dependencies {
     classpath 'mysql:mysql-connector-java:5.1.46'
-    classpath 'com.smartnews:jpa-entity-generator:0.99.2'
+    classpath 'com.smartnews:jpa-entity-generator:0.99.3'
   }
 }
 


### PR DESCRIPTION
In this pull request, `build.gradle` is refactored.

* collect plugins id dispersed in `build.gradle` into `plugins {}` block at the head of `build.gradle`.
* collect configurations for all projects.
* change lombok's scope from `providedCompile` to `compileOnly`. With this change, compile and runtime dependency configurations can be removed. 
