### PR TITLE
Enable doing ./gradlew uploadArchives -Plocal

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ public class Blog {
 }
 ```
 
+### How to test on your local machine
+
+To run the unit tests, simply run the following script as the TravisCI build does.
+
+```sh
+./test.sh
+```
+
+If you need to make sure if your latest code works with sample project or your existing projects, run the following command to publish the latest build to the local Maven repository.
+
+```sh
+./gradlew uploadArchives -Plocal
+```
+
 ### How to release new version
 
 ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ plugins {
     id 'com.dorongold.task-tree' version '1.3'
 }
 
+def isLocalDeployment = project.hasProperty("local")
+
 compileJava {
     sourceCompatibility = '1.8'
 }
@@ -66,7 +68,6 @@ allprojects {
     }
 }
 
-
 task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc
@@ -78,8 +79,11 @@ task sourcesJar(type: Jar) {
 artifacts {
     archives javadocJar, sourcesJar
 }
-signing {
-    sign configurations.archives
+
+if (!isLocalDeployment) {
+    signing {
+        sign configurations.archives
+    }
 }
 
 try {
@@ -88,16 +92,20 @@ uploadArchives {
         mavenDeployer {
             pom.groupId = 'com.smartnews'
             pom.artifactId = 'jpa-entity-generator'
-            pom.version = '0.99.5'
+            pom.version = '0.99.6-SNAPSHOT'
 
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: "$System.env.SONATYPE_NEXUS_USER", password: "$System.env.SONATYPE_NEXUS_PASS")
-            }
-
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: "$System.env.SONATYPE_NEXUS_USER", password: "$System.env.SONATYPE_NEXUS_PASS")
+            if (isLocalDeployment) {
+                def localRepoPath = 'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath
+                repository(url: localRepoPath)
+                snapshotRepository(url: localRepoPath)
+            } else {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                    authentication(userName: "$System.env.SONATYPE_NEXUS_USER", password: "$System.env.SONATYPE_NEXUS_PASS")
+                }
+                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                    authentication(userName: "$System.env.SONATYPE_NEXUS_USER", password: "$System.env.SONATYPE_NEXUS_PASS")
+                }
             }
 
             pom.project {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,12 +2,14 @@ apply plugin: 'java'
 
 buildscript {
     repositories {
+        mavenLocal()
         mavenCentral()
     }
     dependencies {
         classpath 'com.h2database:h2:1.4.197'
 
-        // classpath 'com.smartnews:jpa-entity-generator:0.99.4'
+        // NOTE: when you need to go with a specific version in your local repo, use the following line instead
+        // classpath 'com.smartnews:jpa-entity-generator:0.99.6-SNAPSHOT'
         classpath files('../build/libs/jpa-entity-generator.jar') // running `cd ../; ./gradlew jar` is required
         classpath 'com.google.guava:guava:26.0-jre'
         classpath 'org.apache.commons:commons-lang3:3.8.1'

--- a/sample/src/main/resources/entityGenConfig.yml
+++ b/sample/src/main/resources/entityGenConfig.yml
@@ -50,7 +50,7 @@ tableScanMode: 'All'
 #   - array of TableExclusionRule objects
 #     - tableName (string) / tableNames (array): string value that partially matches table names (case sensitive)
 tableExclusionRules:
-  - tableNames: ["_tmp"]
+  - tableNames: ["^.*_tmp.*$"]
 
 # ---------------------------------------------------------
 # *** Rules for table/class name conversion ***

--- a/test.sh
+++ b/test.sh
@@ -5,6 +5,7 @@ export DB_PASSWORD=pass
 ./gradlew clean test jar && \
 cd sample && \
 ./gradlew entityGen && \
-git diff --exit-code && \
+git add . && \
+git diff --staged --exit-code && \
 cp -pr db testdb && \
 ./gradlew test


### PR DESCRIPTION
Previously, I modified the `build.gradle` when I needed to publish the jar files onto the local repository. This pull request enables instantly doing that just by hitting `./gradlew uploadArchives -Plocal` without any prerequisites. 

Also, I noticed that the TravisCI build didn't detect changes as I expected. In this commit, I've fixed the problem as well. Sorry for doing two things in a single pull request.