### PR TITLE
Remove build settings with old Oracle JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk8
-  - oraclejdk9
-  #- oraclejdk10
   - openjdk8
   - openjdk9
   - openjdk10


### PR DESCRIPTION
The CI builds with Oracle JDK 8 has been failing, plus we no longer need to support the old Oracle JDK versions.