### PR TITLE
Add database columns with CURRENT_TIMESTAMP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Maven plugin to run the code generator is also available.
 ```xml
 <plugin>
   <groupId>com.smartnews</groupId>
-  <artifactId>maven-jpa-entity-generator-plugin</artifactId>
+  <artifactId>jpa-entity-generator-maven-plugin</artifactId>
   <version>0.99.8</version>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.smartnews</groupId>
-    <artifactId>maven-jpa-entity-generator-plugin</artifactId>
+    <artifactId>jpa-entity-generator-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <version>0.99.8</version>
     <name>maven-entitygen-plugin Maven Mojo</name>

--- a/sample/src/main/java/com/example/entity/BlogArticle.java
+++ b/sample/src/main/java/com/example/entity/BlogArticle.java
@@ -39,6 +39,15 @@ public class BlogArticle implements Serializable {
   @Nonnull
   @Column(name = "\"created_at\"", nullable = false)
   private Timestamp createdAt;
+  @Nullable
+  @Column(name = "\"state\"", nullable = true)
+  private Byte state;
+  @Nullable
+  @Column(name = "\"create_time\"", nullable = true, insertable = false, updatable = false)
+  private Timestamp createTime;
+  @Nullable
+  @Column(name = "\"update_time\"", nullable = true, insertable = false, updatable = false)
+  private Timestamp updateTime;
 
   @lombok.Setter(lombok.AccessLevel.NONE)
   @ManyToOne

--- a/sample/src/main/java/com/example/entity/jpa1/BlogArticle.java
+++ b/sample/src/main/java/com/example/entity/jpa1/BlogArticle.java
@@ -39,6 +39,15 @@ public class BlogArticle implements Serializable {
   @Nonnull
   @Column(name = "`created_at`", nullable = false)
   private Timestamp createdAt;
+  @Nullable
+  @Column(name = "`state`", nullable = true)
+  private Byte state;
+  @Nullable
+  @Column(name = "`create_time`", nullable = true, insertable = false, updatable = false)
+  private Timestamp createTime;
+  @Nullable
+  @Column(name = "`update_time`", nullable = true, insertable = false, updatable = false)
+  private Timestamp updateTime;
 
   @lombok.Setter(lombok.AccessLevel.NONE)
   @ManyToOne

--- a/src/main/java/com/smartnews/jpa_entity_generator/CodeGenerator.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/CodeGenerator.java
@@ -100,7 +100,13 @@ public class CodeGenerator {
                 f.setName(fieldName);
                 f.setColumnName(c.getName());
                 f.setNullable(c.isNullable());
-
+                if ((c.getTypeName().equalsIgnoreCase("DATETIME")
+                    || c.getTypeName().equalsIgnoreCase("TIMESTAMP"))
+                    && StringUtils.contains(c.getColumnDef(), "CURRENT_TIMESTAMP")
+                ) {
+                    f.setInsertable(false);
+                    f.setUpdatable(false);
+                }
                 f.setComment(buildFieldComment(className, f.getName(), c, config.getFieldAdditionalCommentRules()));
 
                 f.setAnnotations(config.getFieldAnnotationRules().stream()

--- a/src/main/java/com/smartnews/jpa_entity_generator/CodeGenerator.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/CodeGenerator.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -212,7 +213,7 @@ public class CodeGenerator {
             if (!Files.exists(path)) {
                 Files.createFile(path);
             }
-            Files.write(path, code.getBytes());
+            Files.write(path, code.getBytes(StandardCharsets.UTF_8));
 
             log.debug("path: {}, code: {}", path, code);
         }

--- a/src/main/java/com/smartnews/jpa_entity_generator/CodeRenderer.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/CodeRenderer.java
@@ -80,6 +80,8 @@ public class CodeRenderer {
             private boolean primaryKey;
             private boolean autoIncrement;
             private boolean primitive;
+            private boolean insertable = true;
+            private boolean updatable = true;
             private String generatedValueStrategy;
             private List<Annotation> annotations = new ArrayList<>();
         }

--- a/src/main/java/com/smartnews/jpa_entity_generator/metadata/Column.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/metadata/Column.java
@@ -13,6 +13,7 @@ public class Column {
     private String name;
     private int typeCode;
     private String typeName;
+    private String columnDef;
     private boolean nullable;
     private boolean primaryKey;
     private boolean autoIncrement;

--- a/src/main/java/com/smartnews/jpa_entity_generator/metadata/TableMetadataFetcher.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/metadata/TableMetadataFetcher.java
@@ -72,7 +72,7 @@ public class TableMetadataFetcher {
                     column.setName(rs.getString("COLUMN_NAME"));
                     column.setTypeCode(rs.getInt("DATA_TYPE"));
                     column.setTypeName(rs.getString("TYPE_NAME"));
-
+                    column.setColumnDef(rs.getString("COLUMN_DEF"));
                     // Oracle throws java.sql.SQLException: Invalid column name
                     boolean autoIncrement = false;
                     try {

--- a/src/main/java/com/smartnews/jpa_entity_generator/metadata/TableMetadataFetcher.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/metadata/TableMetadataFetcher.java
@@ -31,7 +31,7 @@ public class TableMetadataFetcher {
         DatabaseMetaData databaseMeta = getMetadata(jdbcSettings);
         try {
             List<String> tableNames = new ArrayList<>();
-            try (ResultSet rs = databaseMeta.getTables(null,  jdbcSettings.getSchemaPattern(), "%", TABLE_TYPES)) {
+            try (ResultSet rs = databaseMeta.getTables(databaseMeta.getConnection().getCatalog(),  jdbcSettings.getSchemaPattern(), "%", TABLE_TYPES)) {
                 while (rs.next()) {
                     tableNames.add(rs.getString("TABLE_NAME"));
                 }
@@ -52,7 +52,8 @@ public class TableMetadataFetcher {
         tableInfo.setSchema(Optional.ofNullable(schema));
         DatabaseMetaData databaseMeta = getMetadata(jdbcSettings);
         try {
-            try (ResultSet rs = databaseMeta.getTables(null, schema, table, TABLE_TYPES)) {
+            String catalog = databaseMeta.getConnection().getCatalog();
+            try (ResultSet rs = databaseMeta.getTables(catalog, schema, table, TABLE_TYPES)) {
                 if (rs.next()) {
                     tableInfo.setDescription(Optional.ofNullable(rs.getString("REMARKS")));
                 }
@@ -61,12 +62,12 @@ public class TableMetadataFetcher {
             }
 
             final List<String> primaryKeyNames = new ArrayList<>();
-            try (ResultSet rs = databaseMeta.getPrimaryKeys(null, schema, table)) {
+            try (ResultSet rs = databaseMeta.getPrimaryKeys(catalog, schema, table)) {
                 while (rs.next()) {
                     primaryKeyNames.add(rs.getString("COLUMN_NAME"));
                 }
             }
-            try (ResultSet rs = databaseMeta.getColumns(null, schema, table, "%")) {
+            try (ResultSet rs = databaseMeta.getColumns(catalog, schema, table, "%")) {
                 while (rs.next()) {
                     Column column = new Column();
                     column.setName(rs.getString("COLUMN_NAME"));

--- a/src/main/java/com/smartnews/jpa_entity_generator/util/TypeConverter.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/util/TypeConverter.java
@@ -18,8 +18,8 @@ public class TypeConverter {
                 return "Long";
             // case Types.BINARY:
             case Types.BIT:
-                // return "Boolean";
-                return "boolean";
+                // my sql
+                return "Boolean";
             case Types.BLOB:
                 return "Blob";
             case Types.BOOLEAN:

--- a/src/main/java/com/smartnews/jpa_entity_generator/util/TypeConverter.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/util/TypeConverter.java
@@ -18,7 +18,6 @@ public class TypeConverter {
                 return "Long";
             // case Types.BINARY:
             case Types.BIT:
-                // my sql
                 return "Boolean";
             case Types.BLOB:
                 return "Blob";

--- a/src/main/resources/entityGen/entity.ftl
+++ b/src/main/resources/entityGen/entity.ftl
@@ -49,7 +49,7 @@ ${field.comment}
 <#if requireJSR305 && !field.primitive>
   <#if field.nullable>@Nullable<#else>@Nonnull</#if>
 </#if>
-  @Column(name = "<#if jpa1Compatible>`<#else>\"</#if>${field.columnName}<#if jpa1Compatible>`<#else>\"</#if>", nullable = ${field.nullable?c})
+  @Column(name = "<#if jpa1Compatible>`<#else>\"</#if>${field.columnName}<#if jpa1Compatible>`<#else>\"</#if>", nullable = ${field.nullable?c}<#if !field.insertable>, insertable = false</#if><#if !field.updatable>, updatable = false</#if>)
   private ${field.type} ${field.name}<#if field.defaultValue??> = ${field.defaultValue}</#if>;
 </#list>
 <#list bottomAdditionalCodeList as code>

--- a/src/test/java/com/example/entity/BlogArticle.java
+++ b/src/test/java/com/example/entity/BlogArticle.java
@@ -33,6 +33,12 @@ public class BlogArticle implements Serializable {
   private Clob tags;
   @Column(name = "\"created_at\"", nullable = false)
   private Timestamp createdAt;
+  @Column(name = "\"state\"", nullable = true)
+  private Byte state;
+  @Column(name = "\"create_time\"", nullable = true, insertable = false, updatable = false)
+  private Timestamp createTime;
+  @Column(name = "\"update_time\"", nullable = true, insertable = false, updatable = false)
+  private Timestamp updateTime;
 
   @lombok.Setter(lombok.AccessLevel.NONE)
   @ManyToOne

--- a/src/test/java/com/example/entity/jpa1/BlogArticle.java
+++ b/src/test/java/com/example/entity/jpa1/BlogArticle.java
@@ -33,6 +33,12 @@ public class BlogArticle implements Serializable {
   private Clob tags;
   @Column(name = "`created_at`", nullable = false)
   private Timestamp createdAt;
+  @Column(name = "`state`", nullable = true)
+  private Byte state;
+  @Column(name = "`create_time`", nullable = true, insertable = false, updatable = false)
+  private Timestamp createTime;
+  @Column(name = "`update_time`", nullable = true, insertable = false, updatable = false)
+  private Timestamp updateTime;
 
   @lombok.Setter(lombok.AccessLevel.NONE)
   @ManyToOne

--- a/src/test/java/com/example/entity2/BlogArticle.java
+++ b/src/test/java/com/example/entity2/BlogArticle.java
@@ -39,4 +39,13 @@ public class BlogArticle implements Serializable {
   @Nonnull
   @Column(name = "\"created_at\"", nullable = false)
   private Timestamp createdAt;
+  @Nullable
+  @Column(name = "\"state\"", nullable = true)
+  private Byte state;
+  @Nullable
+  @Column(name = "\"create_time\"", nullable = true, insertable = false, updatable = false)
+  private Timestamp createTime;
+  @Nullable
+  @Column(name = "\"update_time\"", nullable = true, insertable = false, updatable = false)
+  private Timestamp updateTime;
 }

--- a/src/test/java/com/example/entity2/jpa1/BlogArticle.java
+++ b/src/test/java/com/example/entity2/jpa1/BlogArticle.java
@@ -39,4 +39,13 @@ public class BlogArticle implements Serializable {
   @Nonnull
   @Column(name = "`created_at`", nullable = false)
   private Timestamp createdAt;
+  @Nullable
+  @Column(name = "`state`", nullable = true)
+  private Byte state;
+  @Nullable
+  @Column(name = "`create_time`", nullable = true, insertable = false, updatable = false)
+  private Timestamp createTime;
+  @Nullable
+  @Column(name = "`update_time`", nullable = true, insertable = false, updatable = false)
+  private Timestamp updateTime;
 }

--- a/src/test/java/com/example/unit/DatabaseUtil.java
+++ b/src/test/java/com/example/unit/DatabaseUtil.java
@@ -26,7 +26,10 @@ public class DatabaseUtil {
                     "id integer primary key auto_increment not null, " +
                     "blog_id integer comment 'database comment for blog_id' references blog(id), " +
                     "name varchar(30), tags text, " +
-                    "created_at timestamp not null" +
+                    "created_at timestamp not null, " +
+                    "state TINYINT(1), " +
+                    "create_time datetime DEFAULT CURRENT_TIMESTAMP, " +
+                    "update_time datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" +
                     ")").execute();
             conn.prepareStatement("create table tag (" +
                     "id integer primary key auto_increment not null, " +


### PR DESCRIPTION
## New Feature
1. If using DATETIME with current_timestamp, the corresponding data field need not set, it will generated by database.

## Robustness Improvement
1. change maven plugin artifact to `jpa-entity-generator-maven-plugin`. Because calling it `maven-<yourplugin>-plugin` is an infringement of the Apache Maven Trademark [maven plugin development guide](http://maven.apache.org/guides/plugin/guide-java-plugin-development.html)
2. forcely write bytes as UTF-8
3. support com.mysql.cj.jdbc.Driver. If not set catalog explicitly, it will get all tables from all databases, and if we get columns without catalog, it will may get duplicated columns from tables (from different catalogs) whose name are same.（Tested in mysql connector 8.0.18).