### PR TITLE
@Columns length support

### DIFF
--- a/sample/src/main/java/com/example/entity/ABTest.java
+++ b/sample/src/main/java/com/example/entity/ABTest.java
@@ -23,13 +23,13 @@ public class ABTest implements Serializable, ExpirationPredicate {
 
   @Id
   @Nonnull
-  @Column(name = "\"identifier\"", nullable = false)
+  @Column(name = "\"identifier\"", nullable = false, length = 50)
   private String identifier;
   @Nonnull
   @Column(name = "\"expiration_timestamp\"", nullable = false)
   private Integer expirationTimestamp;
   @Experimental(comment = "The expected data format is JSON")
   @Nullable
-  @Column(name = "\"config\"", nullable = true)
+  @Column(name = "\"config\"", nullable = true, length = 2147483647)
   private String config;
 }

--- a/sample/src/main/java/com/example/entity/Blog.java
+++ b/sample/src/main/java/com/example/entity/Blog.java
@@ -28,7 +28,7 @@ public class Blog implements Serializable {
   @Column(name = "\"id\"", nullable = false)
   private int id;
   @Nullable
-  @Column(name = "\"name\"", nullable = true)
+  @Column(name = "\"name\"", nullable = true, length = 30)
   private String name;
   @Column(name = "\"active\"", nullable = true)
   private boolean active;

--- a/sample/src/main/java/com/example/entity/BlogArticle.java
+++ b/sample/src/main/java/com/example/entity/BlogArticle.java
@@ -30,7 +30,7 @@ public class BlogArticle implements Serializable {
   @Column(name = "\"blog_id\"", nullable = true)
   private Integer blogId;
   @Nullable
-  @Column(name = "\"name\"", nullable = true)
+  @Column(name = "\"name\"", nullable = true, length = 30)
   private String name;
   @Deprecated
   @Nullable

--- a/sample/src/main/java/com/example/entity/Tag.java
+++ b/sample/src/main/java/com/example/entity/Tag.java
@@ -22,8 +22,11 @@ public class Tag implements Serializable {
   @Column(name = "\"id\"", nullable = false)
   private int id;
   @Nullable
-  @Column(name = "\"tag\"", nullable = true)
+  @Column(name = "\"tag\"", nullable = true, length = 100)
   private String tag;
+  @Nullable
+  @Column(name = "\"average\"", nullable = true, precision = 9, scale = 2)
+  private java.math.BigDecimal average;
   @Nonnull
   @Column(name = "\"created_at\"", nullable = false)
   private Timestamp createdAt;

--- a/sample/src/main/java/com/example/entity/jpa1/ABTest.java
+++ b/sample/src/main/java/com/example/entity/jpa1/ABTest.java
@@ -23,13 +23,13 @@ public class ABTest implements Serializable, ExpirationPredicate {
 
   @Id
   @Nonnull
-  @Column(name = "`identifier`", nullable = false)
+  @Column(name = "`identifier`", nullable = false, length = 50)
   private String identifier;
   @Nonnull
   @Column(name = "`expiration_timestamp`", nullable = false)
   private Integer expirationTimestamp;
   @Experimental(comment = "The expected data format is JSON")
   @Nullable
-  @Column(name = "`config`", nullable = true)
+  @Column(name = "`config`", nullable = true, length = 2147483647)
   private String config;
 }

--- a/sample/src/main/java/com/example/entity/jpa1/Blog.java
+++ b/sample/src/main/java/com/example/entity/jpa1/Blog.java
@@ -28,7 +28,7 @@ public class Blog implements Serializable {
   @Column(name = "`id`", nullable = false)
   private int id;
   @Nullable
-  @Column(name = "`name`", nullable = true)
+  @Column(name = "`name`", nullable = true, length = 30)
   private String name;
   @Column(name = "`active`", nullable = true)
   private boolean active;

--- a/sample/src/main/java/com/example/entity/jpa1/BlogArticle.java
+++ b/sample/src/main/java/com/example/entity/jpa1/BlogArticle.java
@@ -30,7 +30,7 @@ public class BlogArticle implements Serializable {
   @Column(name = "`blog_id`", nullable = true)
   private Integer blogId;
   @Nullable
-  @Column(name = "`name`", nullable = true)
+  @Column(name = "`name`", nullable = true, length = 30)
   private String name;
   @Deprecated
   @Nullable

--- a/sample/src/main/java/com/example/entity/jpa1/Tag.java
+++ b/sample/src/main/java/com/example/entity/jpa1/Tag.java
@@ -22,8 +22,11 @@ public class Tag implements Serializable {
   @Column(name = "`id`", nullable = false)
   private int id;
   @Nullable
-  @Column(name = "`tag`", nullable = true)
+  @Column(name = "`tag`", nullable = true, length = 100)
   private String tag;
+  @Nullable
+  @Column(name = "`average`", nullable = true, precision = 9, scale = 2)
+  private java.math.BigDecimal average;
   @Nonnull
   @Column(name = "`created_at`", nullable = false)
   private Timestamp createdAt;

--- a/src/main/java/com/smartnews/jpa_entity_generator/CodeGenerator.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/CodeGenerator.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -131,6 +132,15 @@ public class CodeGenerator {
                         f.setType(TypeConverter.toPrimitiveTypeIfPossible(f.getType()));
                     }
                     f.setPrimitive(isPrimitive(f.getType()));
+                }
+
+                if ("String".equals(f.getType())) {
+                    f.setLength(c.getColumnSize());
+                }
+
+                if ("java.math.BigDecimal".equals(f.getType())) {
+                    f.setPrecision(c.getColumnSize());
+                    f.setScale(c.getDecimalDigits());
                 }
 
                 Optional<FieldDefaultValueRule> fieldDefaultValueRule =

--- a/src/main/java/com/smartnews/jpa_entity_generator/CodeRenderer.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/CodeRenderer.java
@@ -78,6 +78,9 @@ public class CodeRenderer {
             private String columnName;
             private boolean nullable;
             private String type;
+            private Integer length;
+            private Integer precision;
+            private Integer scale;
             private String comment;
             private String defaultValue;
             private boolean primaryKey;

--- a/src/main/java/com/smartnews/jpa_entity_generator/metadata/Column.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/metadata/Column.java
@@ -16,5 +16,7 @@ public class Column {
     private boolean nullable;
     private boolean primaryKey;
     private boolean autoIncrement;
+    private int columnSize;
+    private int decimalDigits;
     private Optional<String> description = Optional.empty();
 }

--- a/src/main/java/com/smartnews/jpa_entity_generator/metadata/TableMetadataFetcher.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/metadata/TableMetadataFetcher.java
@@ -72,6 +72,8 @@ public class TableMetadataFetcher {
                     column.setName(rs.getString("COLUMN_NAME"));
                     column.setTypeCode(rs.getInt("DATA_TYPE"));
                     column.setTypeName(rs.getString("TYPE_NAME"));
+                    column.setColumnSize(rs.getInt("COLUMN_SIZE"));
+                    column.setDecimalDigits(rs.getInt("DECIMAL_DIGITS"));
 
                     // Oracle throws java.sql.SQLException: Invalid column name
                     boolean autoIncrement = false;

--- a/src/main/resources/entityGen/entity.ftl
+++ b/src/main/resources/entityGen/entity.ftl
@@ -49,7 +49,7 @@ ${field.comment}
 <#if requireJSR305 && !field.primitive>
   <#if field.nullable>@Nullable<#else>@Nonnull</#if>
 </#if>
-  @Column(name = "<#if jpa1Compatible>`<#else>\"</#if>${field.columnName}<#if jpa1Compatible>`<#else>\"</#if>", nullable = ${field.nullable?c})
+  @Column(name = "<#if jpa1Compatible>`<#else>\"</#if>${field.columnName}<#if jpa1Compatible>`<#else>\"</#if>", nullable = ${field.nullable?c}<#if field.length??>, length = ${field.length?c}</#if><#if field.precision??>, precision = ${field.precision?c}</#if><#if field.scale??>, scale = ${field.scale?c}</#if>)
   private ${field.type} ${field.name}<#if field.defaultValue??> = ${field.defaultValue}</#if>;
 </#list>
 <#list bottomAdditionalCodeList as code>

--- a/src/test/java/com/example/entity/ABTest.java
+++ b/src/test/java/com/example/entity/ABTest.java
@@ -20,11 +20,11 @@ import lombok.ToString;
 public class ABTest implements Serializable, ExpirationPredicate {
 
   @Id
-  @Column(name = "\"identifier\"", nullable = false)
+  @Column(name = "\"identifier\"", nullable = false, length = 50)
   private String identifier;
   @Column(name = "\"expiration_timestamp\"", nullable = false)
   private Integer expirationTimestamp;
   @Experimental(comment = "The expected data format is JSON")
-  @Column(name = "\"config\"", nullable = true)
+  @Column(name = "\"config\"", nullable = true, length = 2147483647)
   private String config;
 }

--- a/src/test/java/com/example/entity/Blog.java
+++ b/src/test/java/com/example/entity/Blog.java
@@ -21,7 +21,7 @@ public class Blog implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "\"id\"", nullable = false)
   private Integer id;
-  @Column(name = "\"name\"", nullable = true)
+  @Column(name = "\"name\"", nullable = true, length = 30)
   private String name;
   @Column(name = "\"active\"", nullable = true)
   private boolean active;

--- a/src/test/java/com/example/entity/BlogArticle.java
+++ b/src/test/java/com/example/entity/BlogArticle.java
@@ -26,7 +26,7 @@ public class BlogArticle implements Serializable {
    */
   @Column(name = "\"blog_id\"", nullable = true)
   private Integer blogId;
-  @Column(name = "\"name\"", nullable = true)
+  @Column(name = "\"name\"", nullable = true, length = 30)
   private String name;
   @Deprecated
   @Column(name = "\"tags\"", nullable = true)

--- a/src/test/java/com/example/entity/Tag.java
+++ b/src/test/java/com/example/entity/Tag.java
@@ -19,8 +19,10 @@ public class Tag implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "\"id\"", nullable = false)
   private Integer id;
-  @Column(name = "\"tag\"", nullable = true)
+  @Column(name = "\"tag\"", nullable = true, length = 100)
   private String tag;
+  @Column(name = "\"average\"", nullable = true, precision = 9, scale = 2)
+  private java.math.BigDecimal average;
   @Column(name = "\"created_at\"", nullable = false)
   private Timestamp createdAt;
 }

--- a/src/test/java/com/example/entity/jpa1/ABTest.java
+++ b/src/test/java/com/example/entity/jpa1/ABTest.java
@@ -20,11 +20,11 @@ import lombok.ToString;
 public class ABTest implements Serializable, ExpirationPredicate {
 
   @Id
-  @Column(name = "`identifier`", nullable = false)
+  @Column(name = "`identifier`", nullable = false, length = 50)
   private String identifier;
   @Column(name = "`expiration_timestamp`", nullable = false)
   private Integer expirationTimestamp;
   @Experimental(comment = "The expected data format is JSON")
-  @Column(name = "`config`", nullable = true)
+  @Column(name = "`config`", nullable = true, length = 2147483647)
   private String config;
 }

--- a/src/test/java/com/example/entity/jpa1/Blog.java
+++ b/src/test/java/com/example/entity/jpa1/Blog.java
@@ -21,7 +21,7 @@ public class Blog implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "`id`", nullable = false)
   private Integer id;
-  @Column(name = "`name`", nullable = true)
+  @Column(name = "`name`", nullable = true, length = 30)
   private String name;
   @Column(name = "`active`", nullable = true)
   private boolean active;

--- a/src/test/java/com/example/entity/jpa1/BlogArticle.java
+++ b/src/test/java/com/example/entity/jpa1/BlogArticle.java
@@ -26,7 +26,7 @@ public class BlogArticle implements Serializable {
    */
   @Column(name = "`blog_id`", nullable = true)
   private Integer blogId;
-  @Column(name = "`name`", nullable = true)
+  @Column(name = "`name`", nullable = true, length = 30)
   private String name;
   @Deprecated
   @Column(name = "`tags`", nullable = true)

--- a/src/test/java/com/example/entity/jpa1/Tag.java
+++ b/src/test/java/com/example/entity/jpa1/Tag.java
@@ -19,8 +19,10 @@ public class Tag implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "`id`", nullable = false)
   private Integer id;
-  @Column(name = "`tag`", nullable = true)
+  @Column(name = "`tag`", nullable = true, length = 100)
   private String tag;
+  @Column(name = "`average`", nullable = true, precision = 9, scale = 2)
+  private java.math.BigDecimal average;
   @Column(name = "`created_at`", nullable = false)
   private Timestamp createdAt;
 }

--- a/src/test/java/com/example/entity2/BlogArticle.java
+++ b/src/test/java/com/example/entity2/BlogArticle.java
@@ -30,7 +30,7 @@ public class BlogArticle implements Serializable {
   @Column(name = "\"blog_id\"", nullable = true)
   private Integer blogId;
   @Nullable
-  @Column(name = "\"name\"", nullable = true)
+  @Column(name = "\"name\"", nullable = true, length = 30)
   private String name;
   @Deprecated
   @Nullable

--- a/src/test/java/com/example/entity2/jpa1/BlogArticle.java
+++ b/src/test/java/com/example/entity2/jpa1/BlogArticle.java
@@ -30,7 +30,7 @@ public class BlogArticle implements Serializable {
   @Column(name = "`blog_id`", nullable = true)
   private Integer blogId;
   @Nullable
-  @Column(name = "`name`", nullable = true)
+  @Column(name = "`name`", nullable = true, length = 30)
   private String name;
   @Deprecated
   @Nullable

--- a/src/test/java/com/example/entity3/ABTest.java
+++ b/src/test/java/com/example/entity3/ABTest.java
@@ -20,11 +20,11 @@ import lombok.ToString;
 public class ABTest implements Serializable, ExpirationPredicate {
 
   @Id
-  @Column(name = "\"identifier\"", nullable = false)
+  @Column(name = "\"identifier\"", nullable = false, length = 50)
   private String identifier;
   @Column(name = "\"expiration_timestamp\"", nullable = false)
   private Integer expirationTimestamp;
   @Experimental(comment = "The expected data format is JSON")
-  @Column(name = "\"config\"", nullable = true)
+  @Column(name = "\"config\"", nullable = true, length = 2147483647)
   private String config;
 }

--- a/src/test/java/com/example/entity3/Blog.java
+++ b/src/test/java/com/example/entity3/Blog.java
@@ -21,7 +21,7 @@ public class Blog implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "\"id\"", nullable = false)
   private Integer id;
-  @Column(name = "\"name\"", nullable = true)
+  @Column(name = "\"name\"", nullable = true, length = 30)
   private String name;
   @Column(name = "\"active\"", nullable = true)
   private boolean active;

--- a/src/test/java/com/example/entity3/BlogArticle.java
+++ b/src/test/java/com/example/entity3/BlogArticle.java
@@ -26,7 +26,7 @@ public class BlogArticle implements Serializable {
    */
   @Column(name = "\"blog_id\"", nullable = true)
   private Integer blogId;
-  @Column(name = "\"name\"", nullable = true)
+  @Column(name = "\"name\"", nullable = true, length = 30)
   private String name;
   @Deprecated
   @Column(name = "\"tags\"", nullable = true)

--- a/src/test/java/com/example/entity3/Tag.java
+++ b/src/test/java/com/example/entity3/Tag.java
@@ -19,8 +19,10 @@ public class Tag implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "\"id\"", nullable = false)
   private Integer id;
-  @Column(name = "\"tag\"", nullable = true)
+  @Column(name = "\"tag\"", nullable = true, length = 100)
   private String tag;
+  @Column(name = "\"average\"", nullable = true, precision = 9, scale = 2)
+  private java.math.BigDecimal average;
   @Column(name = "\"created_at\"", nullable = false)
   private Timestamp createdAt;
 }

--- a/src/test/java/com/example/entity3/jpa1/ABTest.java
+++ b/src/test/java/com/example/entity3/jpa1/ABTest.java
@@ -20,11 +20,11 @@ import lombok.ToString;
 public class ABTest implements Serializable, ExpirationPredicate {
 
   @Id
-  @Column(name = "`identifier`", nullable = false)
+  @Column(name = "`identifier`", nullable = false, length = 50)
   private String identifier;
   @Column(name = "`expiration_timestamp`", nullable = false)
   private Integer expirationTimestamp;
   @Experimental(comment = "The expected data format is JSON")
-  @Column(name = "`config`", nullable = true)
+  @Column(name = "`config`", nullable = true, length = 2147483647)
   private String config;
 }

--- a/src/test/java/com/example/entity3/jpa1/Blog.java
+++ b/src/test/java/com/example/entity3/jpa1/Blog.java
@@ -21,7 +21,7 @@ public class Blog implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "`id`", nullable = false)
   private Integer id;
-  @Column(name = "`name`", nullable = true)
+  @Column(name = "`name`", nullable = true, length = 30)
   private String name;
   @Column(name = "`active`", nullable = true)
   private boolean active;

--- a/src/test/java/com/example/entity3/jpa1/BlogArticle.java
+++ b/src/test/java/com/example/entity3/jpa1/BlogArticle.java
@@ -26,7 +26,7 @@ public class BlogArticle implements Serializable {
    */
   @Column(name = "`blog_id`", nullable = true)
   private Integer blogId;
-  @Column(name = "`name`", nullable = true)
+  @Column(name = "`name`", nullable = true, length = 30)
   private String name;
   @Deprecated
   @Column(name = "`tags`", nullable = true)

--- a/src/test/java/com/example/entity3/jpa1/Tag.java
+++ b/src/test/java/com/example/entity3/jpa1/Tag.java
@@ -19,8 +19,10 @@ public class Tag implements Serializable {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "`id`", nullable = false)
   private Integer id;
-  @Column(name = "`tag`", nullable = true)
+  @Column(name = "`tag`", nullable = true, length = 100)
   private String tag;
+  @Column(name = "`average`", nullable = true, precision = 9, scale = 2)
+  private java.math.BigDecimal average;
   @Column(name = "`created_at`", nullable = false)
   private Timestamp createdAt;
 }

--- a/src/test/java/com/example/entity4/BlogArticle.java
+++ b/src/test/java/com/example/entity4/BlogArticle.java
@@ -30,7 +30,7 @@ public class BlogArticle implements Serializable {
   @Column(name = "\"blog_id\"", nullable = true)
   private Integer blogId;
   @Nullable
-  @Column(name = "\"name\"", nullable = true)
+  @Column(name = "\"name\"", nullable = true, length = 30)
   private String name;
   @Deprecated
   @Nullable

--- a/src/test/java/com/example/entity4/jpa1/BlogArticle.java
+++ b/src/test/java/com/example/entity4/jpa1/BlogArticle.java
@@ -30,7 +30,7 @@ public class BlogArticle implements Serializable {
   @Column(name = "`blog_id`", nullable = true)
   private Integer blogId;
   @Nullable
-  @Column(name = "`name`", nullable = true)
+  @Column(name = "`name`", nullable = true, length = 30)
   private String name;
   @Deprecated
   @Nullable

--- a/src/test/java/com/example/unit/DatabaseUtil.java
+++ b/src/test/java/com/example/unit/DatabaseUtil.java
@@ -31,6 +31,7 @@ public class DatabaseUtil {
             conn.prepareStatement("create table tag (" +
                     "id integer primary key auto_increment not null, " +
                     "tag varchar(100), " +
+                    "average numeric(9,2), " +
                     "created_at timestamp not null" +
                     ")").execute();
             conn.prepareStatement("create table article_tag (" +


### PR DESCRIPTION
### Changes
Adds `length`, `precision` and `scale` support on @Column annotation.

Concerns only `String` and `java.math.BigDecimal`
