### PR TITLE
Environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ dependencies {
 apply plugin: 'entitygen'
 entityGen {
     configPath = 'src/main/resources/entityGenConfig.yml'
+    // You can pass environment variable here if necessary. System variables takes precedence.
+    // environment = ["JDBC_CONNECTION":"jdbc:"]
 }
 ```
 

--- a/src/main/java/com/smartnews/jpa_entity_generator/config/CodeGeneratorConfig.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/config/CodeGeneratorConfig.java
@@ -6,10 +6,7 @@ import lombok.Data;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -68,20 +65,20 @@ public class CodeGeneratorConfig implements Serializable {
     public CodeGeneratorConfig() {
     }
 
-    public void loadEnvVariables() {
+    public void loadEnvVariables(Map<String, String> environment) {
         // JDBC settings
         JDBCSettings settings = getJdbcSettings();
         if (hasEnvVariables(settings.getUrl())) {
-            settings.setUrl(replaceEnvVariables(settings.getUrl()));
+            settings.setUrl(replaceEnvVariables(settings.getUrl(), environment));
         }
         if (hasEnvVariables(settings.getUsername())) {
-            settings.setUsername(replaceEnvVariables(settings.getUsername()));
+            settings.setUsername(replaceEnvVariables(settings.getUsername(), environment));
         }
         if (hasEnvVariables(settings.getPassword())) {
-            settings.setPassword(replaceEnvVariables(settings.getPassword()));
+            settings.setPassword(replaceEnvVariables(settings.getPassword(), environment));
         }
         if (hasEnvVariables(settings.getDriverClassName())) {
-            settings.setDriverClassName(replaceEnvVariables(settings.getDriverClassName()));
+            settings.setDriverClassName(replaceEnvVariables(settings.getDriverClassName(), environment));
         }
     }
 
@@ -91,11 +88,13 @@ public class CodeGeneratorConfig implements Serializable {
 
     private static final Pattern REPLACE_ENV_VARIABLES_PATTERN = Pattern.compile("(\\$\\{[^}]+\\})");
 
-    static String replaceEnvVariables(String value) {
+    static String replaceEnvVariables(String value, Map<String, String> environment) {
         Matcher matcher = REPLACE_ENV_VARIABLES_PATTERN.matcher(value);
         if (matcher.find()) {
             String replacedValue = value;
-            Map<String, String> envVariables = System.getenv();
+
+            Map<String, String> envVariables = new HashMap<>(environment);
+            envVariables.putAll(System.getenv());
 
             for (int i = 0; i < matcher.groupCount(); i++) {
                 String grouped = matcher.group(i + 1);
@@ -175,11 +174,11 @@ public class CodeGeneratorConfig implements Serializable {
 
     private static final Yaml YAML = new Yaml();
 
-    public static CodeGeneratorConfig load(String path) throws IOException {
+    public static CodeGeneratorConfig load(String path, Map<String, String> environment) throws IOException {
         try (InputStream is = ResourceReader.getResourceAsStream(path)) {
             try (Reader reader = new InputStreamReader(is)) {
                 CodeGeneratorConfig config = YAML.loadAs(reader, CodeGeneratorConfig.class);
-                config.loadEnvVariables();
+                config.loadEnvVariables(environment);
                 config.setUpPresetRules();
                 return config;
             }

--- a/src/main/java/com/smartnews/jpa_entity_generator/config/CodeGeneratorConfig.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/config/CodeGeneratorConfig.java
@@ -89,27 +89,16 @@ public class CodeGeneratorConfig implements Serializable {
     private static final Pattern REPLACE_ENV_VARIABLES_PATTERN = Pattern.compile("(\\$\\{[^}]+\\})");
 
     static String replaceEnvVariables(String value, Map<String, String> environment) {
-        Matcher matcher = REPLACE_ENV_VARIABLES_PATTERN.matcher(value);
-        if (matcher.find()) {
-            String replacedValue = value;
+        Map<String, String> envMap = new HashMap<>(environment);
+        envMap.putAll(System.getenv());
+        String text = value;
 
-            Map<String, String> envVariables = new HashMap<>(environment);
-            envVariables.putAll(System.getenv());
-
-            for (int i = 0; i < matcher.groupCount(); i++) {
-                String grouped = matcher.group(i + 1);
-                String envKey = grouped.replaceAll("[\\$\\{\\}]", "");
-                String envValue = envVariables.get(envKey);
-                if (envValue == null) {
-                    throw new IllegalStateException("Env variable: " + envKey + " was not found!");
-                } else {
-                    replacedValue = replacedValue.replace(grouped, envValue);
-                }
-            }
-            return replacedValue;
-        } else {
-            return value;
+        for (Map.Entry<String, String> entry : envMap.entrySet()) {
+            String k = entry.getKey();
+            String v = entry.getValue();
+            text = text.replaceAll("\\$\\{" + k + "}", v);
         }
+        return text;
     }
 
     public void setUpPresetRules() {

--- a/src/main/java/com/smartnews/jpa_entity_generator/gradle/EntityGenExtension.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/gradle/EntityGenExtension.java
@@ -2,6 +2,9 @@ package com.smartnews.jpa_entity_generator.gradle;
 
 import lombok.Data;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * <pre>
  * entityGen {
@@ -11,6 +14,6 @@ import lombok.Data;
  */
 @Data
 public class EntityGenExtension {
-
     private String configPath = "entityGenConfig.yml";
+    private Map<String, String> environment = new HashMap<>();
 }

--- a/src/main/java/com/smartnews/jpa_entity_generator/gradle/EntityGenTask.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/gradle/EntityGenTask.java
@@ -20,7 +20,7 @@ public class EntityGenTask extends DefaultTask {
         if (ext == null) {
             ext = new EntityGenExtension();
         }
-        CodeGeneratorConfig config = CodeGeneratorConfig.load(ext.getConfigPath());
+        CodeGeneratorConfig config = CodeGeneratorConfig.load(ext.getConfigPath(), ext.getEnvironment());
         if (config.isJpa1SupportRequired()) {
             if (config.getPackageName().equals(config.getPackageNameForJpa1())) {
                 throw new IllegalStateException("packageName and packageNameForJpa1 must be different.");

--- a/src/main/java/com/smartnews/jpa_entity_generator/maven/EntityGenMojo.java
+++ b/src/main/java/com/smartnews/jpa_entity_generator/maven/EntityGenMojo.java
@@ -6,11 +6,16 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * @goal generateAll
  * @phase process-sources
  */
 public class EntityGenMojo extends AbstractMojo {
+
+    protected Map<String, String> environment = new HashMap<>();
 
     /**
      * @parameter configPath
@@ -20,7 +25,7 @@ public class EntityGenMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException {
         try {
-            CodeGeneratorConfig config = CodeGeneratorConfig.load(configPath);
+            CodeGeneratorConfig config = CodeGeneratorConfig.load(configPath, environment);
             CodeGenerator.generateAll(config);
         } catch (Exception e) {
             throw new MojoExecutionException(e.getMessage(), e);

--- a/src/test/java/com/example/CodeGeneratorTest.java
+++ b/src/test/java/com/example/CodeGeneratorTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import com.example.unit.DatabaseUtil;
 
+import java.util.HashMap;
+
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
@@ -21,7 +23,7 @@ public class CodeGeneratorTest {
 
     @Test
     public void _01_generateAll_TableScanMode_Is_Default() throws Exception {
-        CodeGeneratorConfig config = CodeGeneratorConfig.load("entityGenConfig.yml");
+        CodeGeneratorConfig config = CodeGeneratorConfig.load("entityGenConfig.yml", new HashMap<>());
         config.setJpa1SupportRequired(true);
         config.setOutputDirectory("src/test/java");
         CodeGenerator.generateAll(config, true);
@@ -30,7 +32,7 @@ public class CodeGeneratorTest {
 
     @Test
     public void _02_generateAll_TableScanMode_Is_RuleBased() throws Exception {
-        CodeGeneratorConfig config = CodeGeneratorConfig.load("entityGenConfig2.yml");
+        CodeGeneratorConfig config = CodeGeneratorConfig.load("entityGenConfig2.yml", new HashMap<>());
         config.setJpa1SupportRequired(true);
         config.setOutputDirectory("src/test/java");
         CodeGenerator.generateAll(config, true);
@@ -39,7 +41,7 @@ public class CodeGeneratorTest {
 
     @Test
     public void _03_generateAll_TableScanMode_Is_Default_use_Jakarta_no_jsr305() throws Exception {
-        CodeGeneratorConfig config = CodeGeneratorConfig.load("entityGenConfig3.yml");
+        CodeGeneratorConfig config = CodeGeneratorConfig.load("entityGenConfig3.yml", new HashMap<>());
         config.setJpa1SupportRequired(true);
         config.setOutputDirectory("src/test/java");
         CodeGenerator.generateAll(config, true);
@@ -48,7 +50,7 @@ public class CodeGeneratorTest {
 
     @Test
     public void _04_generateAll_TableScanMode_Is_RuleBaseduse_Jakarta_and_jsr305() throws Exception {
-        CodeGeneratorConfig config = CodeGeneratorConfig.load("entityGenConfig4.yml");
+        CodeGeneratorConfig config = CodeGeneratorConfig.load("entityGenConfig4.yml", new HashMap<>());
         config.setJpa1SupportRequired(true);
         config.setOutputDirectory("src/test/java");
         CodeGenerator.generateAll(config, true);

--- a/src/test/java/com/smartnews/jpa_entity_generator/config/CodeGeneratorConfigTest.java
+++ b/src/test/java/com/smartnews/jpa_entity_generator/config/CodeGeneratorConfigTest.java
@@ -50,6 +50,7 @@ public class CodeGeneratorConfigTest {
         assertThat(replaceEnvVariables("${" + k3 + "}", environment), is(v3));
         assertThat(replaceEnvVariables("You can override ${" + k4 + "}", environment), is("You can override " + v4));
         assertThat(replaceEnvVariables("as is $", environment), is("as is $"));
+        assertThat(replaceEnvVariables("${" + k1 + "}${" + k2 + "}", environment), is(v1 + v2));
     }
 
 }

--- a/src/test/java/com/smartnews/jpa_entity_generator/config/CodeGeneratorConfigTest.java
+++ b/src/test/java/com/smartnews/jpa_entity_generator/config/CodeGeneratorConfigTest.java
@@ -2,8 +2,8 @@ package com.smartnews.jpa_entity_generator.config;
 
 import org.junit.Test;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,10 +40,16 @@ public class CodeGeneratorConfigTest {
         String k3 = keys.get(2);
         String v3 = env.get(k3);
 
-        assertThat(replaceEnvVariables("${" + k1 + "} is missing!"), is(v1 + " is missing!"));
-        assertThat(replaceEnvVariables("You are the ${" + k2 + "}"), is("You are the " + v2));
-        assertThat(replaceEnvVariables("${" + k3 + "}"), is(v3));
-        assertThat(replaceEnvVariables("as is $"), is("as is $"));
+        HashMap<String, String> environment = new HashMap<>();
+        String k4 = "test";
+        String v4 = "test";
+        environment.put(k4, v4);
+
+        assertThat(replaceEnvVariables("${" + k1 + "} is missing!", environment), is(v1 + " is missing!"));
+        assertThat(replaceEnvVariables("You are the ${" + k2 + "}", environment), is("You are the " + v2));
+        assertThat(replaceEnvVariables("${" + k3 + "}", environment), is(v3));
+        assertThat(replaceEnvVariables("You can override ${" + k4 + "}", environment), is("You can override " + v4));
+        assertThat(replaceEnvVariables("as is $", environment), is("as is $"));
     }
 
 }


### PR DESCRIPTION
### Changes
* Allow to use .env files with plugin https://github.com/uzzu/dotenv-gradle
* Fix multiple env var replacement in string (ex: `url: "jdbc:sqlserver://${DATABASE_HOST};trustServerCertificate=true;database=${DATABASE_DATABASE}"`)

### Description
The JDK doesn't offer solution to change env vars after start. We use a gradle plugin to load environment variables from .env file. To use this feature with another plugin we should to have an option to pass variables manually.